### PR TITLE
docs: updated text

### DIFF
--- a/docs/api-reference/ai/object-detection.mdx
+++ b/docs/api-reference/ai/object-detection.mdx
@@ -45,7 +45,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
- result = jigsawstack.vision.object_detection({"url": "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Collabo%201080x842.jpg?t=2024-03-22T09%3A22%3A48.442Z"});
+ result = jigsawstack.vision.object_detection({"url": "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Collabo%201080x842.jpg?t=2024-03-22T09%3A22%3A48.442Z"})
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/scrape.mdx
+++ b/docs/api-reference/ai/scrape.mdx
@@ -262,7 +262,7 @@ jigsawstack = JigsawStack(api_key="your-api-key")
 result =  jigsawstack.web.ai_scrape({
   "url": "https://supabase.com/pricing",
   "element_prompts": ["Plan title", "Plan price"],
-});
+})
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/sentiment.mdx
+++ b/docs/api-reference/ai/sentiment.mdx
@@ -79,7 +79,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
- result = jigsawstack.sentiment({ text: "I am happy!" });
+result = jigsawstack.sentiment({ text: "I am happy!" })
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/spam-check.mdx
+++ b/docs/api-reference/ai/spam-check.mdx
@@ -59,7 +59,7 @@ const result = await jigsawstack.spamcheck({ text: "I am happy!" });
 from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
-result = jigsawstack.validate.spamcheck({"text": "I am happy!"});
+result = jigsawstack.validate.spamcheck({"text": "I am happy!"})
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/speech-to-text.mdx
+++ b/docs/api-reference/ai/speech-to-text.mdx
@@ -71,7 +71,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
-result = jigsawstack.audio.speech_to_text({ "url": "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Video%201737458382653833217.mp4?t=2024-03-22T09%3A50%3A49.894Z"});
+result = jigsawstack.audio.speech_to_text({ "url": "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Video%201737458382653833217.mp4?t=2024-03-22T09%3A50%3A49.894Z"})
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/summary.mdx
+++ b/docs/api-reference/ai/summary.mdx
@@ -75,7 +75,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
-result = jigsawstack.summary({"text": "The Leaning Tower of Pisa, or simply, the Tower of Pisa, is the campanile, or freestanding bell tower, of Pisa Cathedral." });
+result = jigsawstack.summary({"text": "The Leaning Tower of Pisa, or simply, the Tower of Pisa, is the campanile, or freestanding bell tower, of Pisa Cathedral." })
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/text-to-sql.mdx
+++ b/docs/api-reference/ai/text-to-sql.mdx
@@ -57,7 +57,7 @@ params = {
     "prompt": "Generate a query to get transactions that amount exceed 10000 and sort by when created",
     "sql_schema": "CREATE TABLE Transactions (transaction_id INT PRIMARY KEY, user_id INT NOT NULL,total_amount DECIMAL(10, 2 NOT NULL, transaction_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,status VARCHAR(20) DEFAULT 'pending',FOREIGN KEY(user_id) REFERENCES Users(user_id))"
 }
-result = jigsawstack.text_to_sql(params);
+result = jigsawstack.text_to_sql(params)
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/translate.mdx
+++ b/docs/api-reference/ai/translate.mdx
@@ -12,6 +12,7 @@ description: "Translate text from one language to another."
 
 <ParamField body="target_language" type="string" required>
   The language code of the text to translate to.
+  All supported language codes can be found [here](https://jigsawstack.com/docs/additional-resources/languages)
 </ParamField>
 
 <ParamField body="text" type="string" required>
@@ -60,7 +61,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
-result = jigsawstack.translate({ text: "Hello, world!", target_language:"es", current_language:"en" });
+result = jigsawstack.translate({ text: "Hello, world!", target_language:"es", current_language:"en" })
 ```
 
 ```bash cURL

--- a/docs/api-reference/ai/vision.mdx
+++ b/docs/api-reference/ai/vision.mdx
@@ -79,7 +79,7 @@ description: "Recognise, describe and retrieve data within an image with great a
 
   jigsawstack = JigsawStack(api_key="your-api-key")
 
-  result = jigsawstack.vision.vocr({"url": "https://res.cloudinary.com/dev-ninja/image/upload/v1712567895/webhooks_qaaslj.png", "prompt" : ["Title", "Description"]});
+  result = jigsawstack.vision.vocr({"url": "https://res.cloudinary.com/dev-ninja/image/upload/v1712567895/webhooks_qaaslj.png", "prompt" : ["Title", "Description"]})
   ```
 
   ```bash cURL

--- a/docs/api-reference/geo/geocode.mdx
+++ b/docs/api-reference/geo/geocode.mdx
@@ -75,7 +75,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
-result = jigsawstack.geo.geocode({ "lat": 40.78337,"lng": -73.96442, });
+result = jigsawstack.geo.geocode({ "lat": 40.78337,"lng": -73.96442, })
 ```
 
 ```bash cURL

--- a/docs/api-reference/store/file/delete.mdx
+++ b/docs/api-reference/store/file/delete.mdx
@@ -35,7 +35,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
-result = jigsawstack.store.delete("jigsaw");
+result = jigsawstack.store.delete("jigsaw")
 ```
 
 ```bash cURL

--- a/docs/api-reference/store/kv/delete.mdx
+++ b/docs/api-reference/store/kv/delete.mdx
@@ -39,7 +39,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
-result = jigsawstack.store.kv.delete("jigsaw");
+result = jigsawstack.store.kv.delete("jigsaw")
 ```
 
 ```bash cURL

--- a/docs/api-reference/store/kv/get.mdx
+++ b/docs/api-reference/store/kv/get.mdx
@@ -47,7 +47,7 @@ from jigsawstack import JigsawStack
 
 jigsawstack = JigsawStack(api_key="your-api-key")
 
-result = jigsawstack.store.kv.get("jigsaw");
+result = jigsawstack.store.kv.get("jigsaw")
 ```
 
 ```bash cURL

--- a/docs/api-reference/validate/nsfw.mdx
+++ b/docs/api-reference/validate/nsfw.mdx
@@ -41,7 +41,7 @@ from jigsawstack import JigsawStack
 jigsawstack = JigsawStack(api_key="your-api-key")
 
 url = ""
-result = jigsawstack.validate.nsfw(url);
+result = jigsawstack.validate.nsfw(url)
 ```
 
 ```bash cURL

--- a/docs/api-reference/validate/profanity.mdx
+++ b/docs/api-reference/validate/profanity.mdx
@@ -61,7 +61,7 @@ jigsawstack = JigsawStack(api_key="your-api-key")
 result = jigsawstack.validate.profanity({
   "text": "All the world's a stage, and all the men and women merely players. They have their exits and their entrances; And one man in his time plays many parts.",
   "censor_replacement": "*",
-});
+})
 ```
 
 ```bash cURL

--- a/docs/api-reference/validate/spellcheck.mdx
+++ b/docs/api-reference/validate/spellcheck.mdx
@@ -60,7 +60,7 @@ jigsawstack = JigsawStack(api_key="your-api-key")
 result = jigsawstack.validate.spellcheck({
   "text": "All the world's a stage, and all the men and women merely players. They have their exits and their entrances; And one man in his time plays many parts.",
   "language_code": "en",
-});
+})
 ```
 
 ```bash cURL

--- a/docs/api-reference/web/ai-search.mdx
+++ b/docs/api-reference/web/ai-search.mdx
@@ -64,7 +64,7 @@ result = jigsawstack.web.search({
   "query": "Time Square New Yor",
   "safe_search": "strict",
   "spell_check": true,
-});
+})
 ```
 
 ```bash cURL

--- a/docs/api-reference/web/html-to-any.mdx
+++ b/docs/api-reference/web/html-to-any.mdx
@@ -136,7 +136,7 @@ result = jigsawstack.web.html_to_any({
   "full_page": true,
   "omit_background": false,
   "type": "jpeg",
-});
+})
 ```
 
 ```bash cURL

--- a/docs/api-reference/web/scrape.mdx
+++ b/docs/api-reference/web/scrape.mdx
@@ -60,8 +60,8 @@ For more information on selectors click [here](/docs/learn/web/selector)
 <ParamField body="goto_options" type="object">
   This parameter allows you to specify custom page-load behavior.
   <Expandable title="property">
-    <ResponseField name="timeout" type="number" default="15000">
-      Custom timeout in milliseconds. Maximum value is 15000(15seconds)
+    <ResponseField name="timeout" type="number" default="30000">
+      Custom timeout in milliseconds. Maximum value is 40000 (40 seconds)
     </ResponseField>
     <ResponseField name="wait_until" type="string" default="load">
       <ul>
@@ -88,7 +88,7 @@ Wait for.
   <ParamField body="value" type="string|number">
     This parameter can accept one of three options:
     <ul>
-      <li>A number indicating the time in milliseconds to wait. Maximum timeout  `15000`</li>
+      <li>A number indicating the time in milliseconds to wait. Maximum timeout  `40000`</li>
       <li>A valid selector to wait for. e.g `h2`</li>
        <li>
         A function to be ran within the page's context, inside of the browser.
@@ -168,7 +168,7 @@ jigsawstack = JigsawStack(api_key="your-api-key")
 
 result = jigsawstack.web.scrape({
   "url": "https://jigsawstack.com",
-});
+})
 ```
 
 ```bash cURL

--- a/docs/api-reference/web/search-suggestion.mdx
+++ b/docs/api-reference/web/search-suggestion.mdx
@@ -28,7 +28,7 @@ const jigsawstack = JigsawStack({
 });
 
 const result = await jigsawstack.web.search_suggestion({
-  query: "Time Square New Yor",
+  query: "Time Square New York",
 });
 ```
 
@@ -38,8 +38,8 @@ from jigsawstack import JigsawStack
 jigsawstack = JigsawStack(api_key="your-api-key")
 
 result = jigsawstack.web.search_suggestion({
-  "query": "Time Square New Yor",
-});
+  "query": "Time Square New York",
+})
 ```
 
 ```bash cURL

--- a/docs/examples/file-upload.mdx
+++ b/docs/examples/file-upload.mdx
@@ -156,7 +156,7 @@ const publicFileUrl = `${result.url}?x-api-key=${publicKey}`;
 ```
 
 ```python python
- publicFileUrl = f"{result.url}?x-api-key={publicKey}";
+ publicFileUrl = f"{result.url}?x-api-key={publicKey}"
 ```
 
 </CodeGroup>
@@ -209,7 +209,7 @@ try:
 
         // Retrieve the file key.
        fileKey = result.key
-     result = jigsawstack.vision.vocr({"file_store_key":fileKey,"prompt" : "Describe the image in detail"});
+     result = jigsawstack.vision.vocr({"file_store_key":fileKey,"prompt" : "Describe the image in detail"})
 
 
 except JigsawStackError as err:

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -8,13 +8,9 @@ description: "Welcome to the JigsawStack docs! Learn about how to use and integr
 
 JigsawStack is a unified API platform that offers developers and non-coders a consistent and fast experience, with a suite of highly reliable APIs at a low cost.
 
-_*Here are some of the benefits of using JigsawStack API:*_
-
-- Consistency: JigsawStack provides a consistent API interface for all of the services it encapsulates. This means that you can use the same code to access data and functionality from different services, regardless of their underlying implementation.
-- Speed: JigsawStack is served on the edge network, so your requests are always delivered quickly and reliably. This is especially important for applications that require low latency or high availability.
-- Ease of use: JigsawStack is easy to use and integrate with your applications. The documentation is clear and concise, and the API is well-designed.
-
 ## Prerequisites
+
+View the full list of APIs [here](https://jigsawstack.com/docs/api-reference/)
 
 To get the most out of this guide, you’ll need to:
 
@@ -35,6 +31,8 @@ npm install jigsawstack
 yarn add jigsawstack
 # or
 pnpm add jigsawstack
+# or 
+bun i jigsawstack
 ```
 
 ```bash python


### PR DESCRIPTION
updated docs so:
-all the python examples were formatted correctly and fixed spelling errors. 
-under the Translate API the goto option is max of 40000, defaults to 30000 and waitfor max is now 40000. Also added a link to languages supported
-removed benefits sections on the intro page
-added a link to the full list of APIs to the Introduction page
-added bun i jigsawstack option to the Installation section