### PR TITLE
Updating examples/text-to-speech.mdx:

### DIFF
--- a/docs/examples/text-to-speech.mdx
+++ b/docs/examples/text-to-speech.mdx
@@ -22,7 +22,7 @@ const jigsawstack = JigsawStack({
 
 const resp = await jigsawstack.audio.text_to_speech({
   text: "Hello, how are you doing?",
-  accent: "en-US-male-1",
+  accent: "en-US-female-27",
 });
 
 const data = await resp.blob();


### PR DESCRIPTION
1. The speaker voice "en-US-male-1" was removed previously.
2. Updating the outdated example's voice to "en-US-female-27"