### PR TITLE
feat: update object-detection api-ref to mention retrun_masks param.

### DIFF
--- a/docs/api-reference/ai/object-detection.mdx
+++ b/docs/api-reference/ai/object-detection.mdx
@@ -29,6 +29,10 @@ import FilesParam from "/snippets/helpers/params/files-param.mdx";
   Format for returning images. Available options: `url`, `base64`.
 </ParamField>
 
+<ParamField body="return_masks" type="boolean" default="false">
+  Binary segmentation masks for detected objects. 
+</ParamField>
+
 <Info>Either `file_store_key` or `url` can be provided not both.</Info>
 
 <Snippet file="header.mdx" />


### PR DESCRIPTION
* Added a new boolean parameter `return_masks` to the object detection API reference, allowing users to request binary segmentation masks for detected objects.